### PR TITLE
Remove height

### DIFF
--- a/lib/youtube-pane-view.coffee
+++ b/lib/youtube-pane-view.coffee
@@ -3,8 +3,7 @@
 module.exports =
 class YoutubePaneView extends View
   @content: ->
-    @div class:'styleguide padded pane-item native-key-bindings' , =>
-      @div class: 'youtube'
+    @div class: 'youtube native-key-bindings'
 
   # Returns an object that can be retrieved when package is activated
   serialize: ->

--- a/lib/youtube-pane.coffee
+++ b/lib/youtube-pane.coffee
@@ -22,18 +22,12 @@ module.exports = YoutubePane =
     @subscriptions.add atom.commands.add 'atom-workspace', 'youtube-pane:enlarge': => @enlarge()
 
     $(document).ready ->
-      height = $(window).height()
-      console.log height
       width = $(window).width()
       $('.youtube').width(width / 3)
-      $('.youtube').append('<webview id="youtube-pane" src="https:/m.youtube.com/" style="display:inline-block; float: right; width:' + width / 3 +'px; height:' + height + 'px;"></webview>')
+      $('.youtube').append('<webview id="youtube-pane" src="https:/m.youtube.com/" style="position:absolute; top:0; left:0; right:0; bottom:0;"></webview>')
       $(window).on 'resize' , ->
-        height = $(window).height()
         width = $(window).width()
         $('.youtube').width(width / 3)
-        $('.youtube').height(height)
-        $('#youtube-pane').width(width / 3)
-        $('#youtube-pane').height(height)
 
 
 
@@ -55,10 +49,8 @@ module.exports = YoutubePane =
 
   enlarge: ->
     if @enlarged == false
-      $('#youtube-pane').width($(window).width() / 2)
       $('.youtube').width($(window).width() / 2)
       @enlarged = true
     else
-      $('#youtube-pane').width($(window).width() / 3)
       $('.youtube').width($(window).width() / 3)
       @enlarged = false

--- a/styles/youtube-pane.less
+++ b/styles/youtube-pane.less
@@ -4,7 +4,8 @@
 // for a full listing of what's available.
 @import "ui-variables";
 
-.youtube-pane {
+.youtube {
+  min-width: 426px; // minimum width used by the YouTube player
 }
 
 .resizable {


### PR DESCRIPTION
This PR removes the fixed height and adds support for the upcoming header/footer panels. See https://github.com/atom/atom/pull/9274.

:warning: Only merge this PR after Atom `1.6.0` is released.
## Details

Currently the height in youtube-pane gets set based on the window height, but then it will cover (or be covered) if other packages add header/footer panels. Notice how the bottom part or YouTube can't be seen/scrolled:

![screen shot 2016-02-09 at 1 09 03 pm](https://cloud.githubusercontent.com/assets/378023/12907412/5bdc0312-cf2e-11e5-9849-6cbb89cd8e69.png)

So this PR makes the height flexible:

![screen shot 2016-02-09 at 1 08 14 pm](https://cloud.githubusercontent.com/assets/378023/12907433/bab79702-cf2e-11e5-88ca-a0a7db2f4f75.png)

Note: The "enlarge" command doesn't seem to work, but it's already broken before this PR. Same with the specs.
