### PR TITLE
Add Youtube panel

### DIFF
--- a/lib/youtube-pane.coffee
+++ b/lib/youtube-pane.coffee
@@ -1,5 +1,5 @@
 YoutubePaneView = require './youtube-pane-view'
-
+YoutubePanelView = require './youtube-panel-view'
 
 {CompositeDisposable} = require 'atom'
 
@@ -10,6 +10,7 @@ module.exports = YoutubePane =
   subscriptions: null
   enlarged : false
   youtubePane: null
+  youtubePanel: null
 
   activate: (state) ->
     @youtubePaneView = new YoutubePaneView(state.youtubePaneViewState)
@@ -31,6 +32,14 @@ module.exports = YoutubePane =
     @youtubePane = document.getElementsByClassName("youtube")[0]
     @youtubePane.appendChild(@webview)
 
+    #BottomPanel
+    @youtubePanel = new YoutubePanelView()
+    atom.workspace.addBottomPanel(item: @youtubePanel.getElement())
+    #Update the panel content every 5 seconds
+    setInterval =>
+      @updatePanel()
+    , 5000
+
   deactivate: ->
     @modalPanel.destroy()
     @subscriptions.dispose()
@@ -38,6 +47,9 @@ module.exports = YoutubePane =
 
   serialize: ->
     youtubePaneViewState: @youtubePaneView.serialize()
+
+  updatePanel: ->
+    @youtubePanel.updatePanel @webview.getTitle()
 
   toggle: ->
     console.log 'YoutubePane was toggled!'

--- a/lib/youtube-panel-view.coffee
+++ b/lib/youtube-panel-view.coffee
@@ -1,0 +1,14 @@
+{View} = require '../node_modules/atom-space-pen-views'
+
+module.exports =
+class YoutubePanelView extends View
+  @content: ->
+    @div class: 'youtube-panel', =>
+      @span id: 'youtube-panel'
+
+  getElement: ->
+    @element
+
+  updatePanel: (name) ->
+    panel = document.getElementById 'youtube-panel'
+    panel.innerText = name

--- a/styles/youtube-pane.less
+++ b/styles/youtube-pane.less
@@ -9,6 +9,9 @@
   min-width: 500px;
 }
 
+.youtube-panel {
+  text-align: right;
+}
 
 .resizable {
     position: relative;


### PR DESCRIPTION
It updates every 5 seconds.

When I'm using the package, I have to toggle the Youtube pane, again and again, to check which video is playing.

The panel allows us to see the playing video title without toggling the pane.

*It can be better with some icon or modal or tooltip, but for now, keep it simple.

![screen shot 2017-01-04 at 18 16 08](https://cloud.githubusercontent.com/assets/2560096/21651798/5a29bc5a-d2aa-11e6-9857-858292fb9627.png)
